### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/martijn0937/89c4fd87-048e-49a5-945e-a01a58ad031b/b980f9b1-99a8-42d9-b7bd-3848fda7ae38/_apis/work/boardbadge/637ec162-e834-4a90-b937-2c0f710c31a5)](https://dev.azure.com/martijn0937/89c4fd87-048e-49a5-945e-a01a58ad031b/_boards/board/t/b980f9b1-99a8-42d9-b7bd-3848fda7ae38/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/martijn0937/89c4fd87-048e-49a5-945e-a01a58ad031b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.